### PR TITLE
Add babel-runtime as a dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,10 +150,8 @@ Trine has been designed to be modular and decoupled from the ground up. Each exp
 Trine is available on [npm](https://www.npmjs.com/):
 
 ```
-npm install --save trine babel-runtime
+npm install --save trine
 ```
-
-At the moment, Trine requires you to also install the `babel-runtime` package, and depending on your usage, probably also some polyfills.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "number",
     "value"
   ],
+  "dependencies":{
+    "babel-runtime": "^5.5.6"
+  },
   "devDependencies": {
     "babel": "^5.5.6",
     "babel-runtime": "^5.5.6",


### PR DESCRIPTION
`babel-runtime` should be automatically installed by npm if it's required to run trine correctly. Not doing so breaks all of the current conventions of node packaging and makes it more difficult for people to use or understand your package