### PR TITLE
Babel runtime as a dependency instead of dev-dep

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,10 +150,8 @@ Trine has been designed to be modular and decoupled from the ground up. Each exp
 Trine is available on [npm](https://www.npmjs.com/):
 
 ```
-npm install --save trine babel-runtime
+npm install --save trine
 ```
-
-At the moment, Trine requires you to also install the `babel-runtime` package, and depending on your usage, probably also some polyfills.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -28,9 +28,11 @@
     "number",
     "value"
   ],
+  "dependencies": {
+    "babel-runtime": "^5.5.6"
+  },
   "devDependencies": {
     "babel": "^5.5.6",
-    "babel-runtime": "^5.5.6",
     "chai": "^3.0.0",
     "coveralls": "^2.11.2",
     "glob": "^5.0.10",


### PR DESCRIPTION
This is a reworked version of #6.