### PR TITLE
Implement `iterable/repeat`

### DIFF
--- a/src/iterable/repeat.js
+++ b/src/iterable/repeat.js
@@ -1,0 +1,26 @@
+/**
+ * Indefinitely repeat the values of a given iterator.
+ *
+ * @this {Iterable<T>}
+ * @example Basic Usage
+ *
+ * ```javascript
+ * [1,2,3]::repeat(); // yields [1,2,3,1,2,3...]
+ * ```
+*/
+export function * repeat <T> (
+
+) : Iterable<T> {
+    let iterator = this[Symbol.iterator]();
+
+    while ( true ) {
+        const { value, done } = iterator.next();
+
+        if ( done ) {
+            // Start the iterator over again once done.
+            iterator = this[Symbol.iterator]();
+        } else {
+            yield value;
+        }
+    }
+};

--- a/src/iterable/repeat.js
+++ b/src/iterable/repeat.js
@@ -11,16 +11,9 @@
 export function * repeat <T> (
 
 ) : Iterable<T> {
-    let iterator = this[Symbol.iterator]();
+    const items = [...this];
 
     while ( true ) {
-        const { value, done } = iterator.next();
-
-        if ( done ) {
-            // Start the iterator over again once done.
-            iterator = this[Symbol.iterator]();
-        } else {
-            yield value;
-        }
+        yield * items;
     }
 };

--- a/test/spec/iterable/repeatSpec.js
+++ b/test/spec/iterable/repeatSpec.js
@@ -1,0 +1,8 @@
+import { head } from "../../../src/iterable/head";
+import { repeat } from "../../../src/iterable/repeat";
+
+describe("repeat()", function () {
+    it("indefinitely repeats the values of an iterator", function () {
+        [...[1,2,3]::repeat()::head(6)].should.deep.equal([1,2,3,1,2,3]);
+    });
+});

--- a/test/spec/iterable/repeatSpec.js
+++ b/test/spec/iterable/repeatSpec.js
@@ -1,8 +1,28 @@
+import { to } from "../../../src/iterable/head";
 import { head } from "../../../src/iterable/head";
 import { repeat } from "../../../src/iterable/repeat";
 
 describe("repeat()", function () {
     it("indefinitely repeats the values of an iterator", function () {
         [...[1,2,3]::repeat()::head(6)].should.deep.equal([1,2,3,1,2,3]);
+    });
+
+    describe("when given a non-restartable iterator", function () {
+        it("indefinitely repeats the values of the iterator", function () {
+            function * step (start, amount) {
+                let current = start;
+                while ( true ) {
+                    yield current;
+                    current += amount;
+                }
+            }
+
+            [...step(2, 2)
+                ::head(3)
+                ::repeat()
+                ::head(6)
+            ]
+                .should.deep.equal([2, 4, 6, 2, 4, 6]);
+        });
     });
 });


### PR DESCRIPTION
This commit implements a `repeat()` function for indefinitely repeating a given iterator as specified in #13 and #16.