### PR TITLE
Pass items to transformer in `iterable/map`.

### DIFF
--- a/src/iterable/map.js
+++ b/src/iterable/map.js
@@ -18,6 +18,6 @@ export function * map <iT, rT> (
     transformer : (_this : iT) => rT,
 ) : Iterable<rT> {
     for ( const item of this ) {
-        yield item::transformer();
+        yield item::transformer(item);
     }
 };

--- a/test/spec/iterable/mapSpec.js
+++ b/test/spec/iterable/mapSpec.js
@@ -4,6 +4,8 @@ describe("map()", function () {
     it("should map the items over a transformer method", function () {
         [...[1,2,3]::map(function () {
             return this * 2;
-        })].should.deep.equal([2,4,6])
+        })].should.deep.equal([2,4,6]);
+
+        [...[1,2,3]::map(item => item * 2)].should.deep.equal([2,4,6])
     });
 });


### PR DESCRIPTION
This allows the use of ES6 lambdas in `iterable/map` rather than relying solely on function binding.

This...

```js
[1, 2, 3]::map(function () { return this * 2 })
```

...can therefore be shortened to:

```js
[1, 2, 3]::map(x => x * 2)
```