### PR TITLE
fix xor

### DIFF
--- a/src/boolean/xor.js
+++ b/src/boolean/xor.js
@@ -15,5 +15,5 @@
 export function xor (
     right : boolean,
 ) : boolean {
-    return Boolean(Number(this) ^ Number(right));
+    return this !== right;
 };


### PR DESCRIPTION
xor is just an inequality check. There's no need to go through the overhead of casting to `Number`s and doing a bitwise xor.